### PR TITLE
Fix types for useink/chains

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -9,14 +9,11 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "incremental": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.js"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
TypeScript v 4.5 and above can resolve multiple exports of types. This implements one of the solutions found [here](https://stackoverflow.com/questions/58990498/package-json-exports-field-not-working-with-typescript)